### PR TITLE
project-analyze skill: deep-scan, extraction patterns, fix proj: prefix

### DIFF
--- a/internal/setup/embedded/claude/skills/project-analyze.md
+++ b/internal/setup/embedded/claude/skills/project-analyze.md
@@ -98,7 +98,7 @@ A folder name (`contacts/`, `контакти/`, `suppliers/`, `materials/`, `м
 **Procedure:**
 
 1. **List recursively** to depth 3–4: `find . -maxdepth 4 -type f \( -name "*.md" -o -name "*.txt" -o -name "*.csv" -o -name "*.json" -o -name "*.yaml" -o -name "*.html" \) | head -200`. Note total count.
-2. **Identify content-bearing subfolders.** Any subfolder with ≥1 `.md`/`.txt` is a candidate. Almost always rich in extractable entities: `contacts/`, `контакти/`, `suppliers/`, `постачальники/`, `materials/`, `матеріали/`, `vendors/`, `people/`, `decisions/`, `etapy/`, `етапи/`, `meetings/`, `quotes/`, `bom/`, `quotes/`.
+2. **Identify content-bearing subfolders.** Any subfolder with ≥1 `.md`/`.txt` is a candidate. Almost always rich in extractable entities: `contacts/`, `контакти/`, `suppliers/`, `постачальники/`, `materials/`, `матеріали/`, `vendors/`, `people/`, `decisions/`, `etapy/`, `етапи/`, `meetings/`, `quotes/`, `bom/`.
 3. **Read every leaf file** in those subfolders (not just folder-level README). For projects with >50 files, prioritize: per-folder README → files referenced from README → remaining files in batches.
 4. **Extract structured signals from each file body** — see Step 6 patterns table.
 5. **Re-read the top-level README/index at the end** so cross-links to extracted entities aren't missed.

--- a/internal/setup/embedded/claude/skills/project-analyze.md
+++ b/internal/setup/embedded/claude/skills/project-analyze.md
@@ -59,13 +59,16 @@ Use the `hippo:` namespace (`https://hippocamp.dev/ontology#`). Core types:
 graph action=prefix_add prefix=hippo uri=https://hippocamp.dev/ontology#
 graph action=prefix_add prefix=rdfs uri=http://www.w3.org/2000/01/rdf-schema#
 graph action=prefix_add prefix=rdf uri=http://www.w3.org/1999/02/22-rdf-syntax-ns#
-graph action=prefix_add prefix=proj uri=https://hippocamp.dev/project/
 ```
 
 Derive the project name from the directory name. Create a named graph:
 ```
 graph action=create name=project:{name}
 ```
+
+**Do NOT register a `proj:` prefix mapping `https://hippocamp.dev/project/`.** Slashes are not valid in the local part of a TriG/Turtle prefixed name, so `proj:topic/foo` will fail to parse with `expected ':' in prefixed name`. Always write the full URI: `<https://hippocamp.dev/project/{name}/topic/foo>`. The only safe shortcuts are predicates whose local part has no slash (e.g. `hippo:summary`, `rdfs:label`).
+
+Note: `graph action=import` ignores the named-graph parameter and writes to the default graph. To target a named graph, use `triple action=add graph=project:{name}` or `sparql query="INSERT DATA { ... }" graph=project:{name}`.
 
 ### Step 1.5: Check existing graph state and apply migrations
 
@@ -88,15 +91,29 @@ Check if `.claude/.hippocamp-stale` exists. If it does:
 
 If `.claude/.hippocamp-stale` does NOT exist, proceed with full analysis below.
 
-### Step 3: Scan the project
+### Step 3: Scan the project — DEEP, not shallow
 
-Read the directory structure and key files (README, any `.md`, `.txt`, `.csv`, `.json`, `.yaml` files). Identify:
-- What is this project about?
-- What are the major topic areas? (folders, document sections)
-- Who are the key people, organizations, entities?
-- What decisions have been made?
-- What questions are open?
-- What reference materials exist?
+A folder name (`contacts/`, `контакти/`, `suppliers/`, `materials/`, `матеріали/`, `decisions/`, `meetings/`) is **a hint about content, not the content itself**. You MUST open the files inside before claiming the project is indexed. Reading only the root README and listing immediate subfolders is the most common reason a graph comes out impoverished.
+
+**Procedure:**
+
+1. **List recursively** to depth 3–4: `find . -maxdepth 4 -type f \( -name "*.md" -o -name "*.txt" -o -name "*.csv" -o -name "*.json" -o -name "*.yaml" -o -name "*.html" \) | head -200`. Note total count.
+2. **Identify content-bearing subfolders.** Any subfolder with ≥1 `.md`/`.txt` is a candidate. Almost always rich in extractable entities: `contacts/`, `контакти/`, `suppliers/`, `постачальники/`, `materials/`, `матеріали/`, `vendors/`, `people/`, `decisions/`, `etapy/`, `етапи/`, `meetings/`, `quotes/`, `bom/`, `quotes/`.
+3. **Read every leaf file** in those subfolders (not just folder-level README). For projects with >50 files, prioritize: per-folder README → files referenced from README → remaining files in batches.
+4. **Extract structured signals from each file body** — see Step 6 patterns table.
+5. **Re-read the top-level README/index at the end** so cross-links to extracted entities aren't missed.
+
+A skip is only acceptable for: binary/image folders (`фото/`, `attachment/`, `*.png|jpg|stl|f3d|pdf`), archive folders (`archive/`), generated content (`node_modules/`, `dist/`, `target/`), and per-day journals (index by month, not per file).
+
+**Sanity check before moving on:** count extracted entities. If a project has rich subfolders (e.g. `contacts/` with 7 files) but you ended up with <5 entities, you scanned too shallow — go back. A typical content-bearing folder yields ≥1 entity per file.
+
+Capture per project:
+- What is this project about? (root README, Home.md, top file)
+- Major topic areas? (folders + document sections inside files)
+- Key people/organizations/products/places? (extract from contact files, vendor lists, comparison tables)
+- Decisions with rationale? (look for `Decision:`, `Вибрано:`, `Рішення:`, ✅, winner rows in comparison tables)
+- Open questions? (`TODO`, `Питання:`, `?`, `Потрібно з'ясувати`)
+- Reference materials? (URLs, PDFs, external standards, datasheets)
 
 ### Step 4: Create the project entity
 
@@ -116,6 +133,22 @@ triple action=add graph=project:{name} subject=https://hippocamp.dev/project/{na
 ```
 
 ### Step 6: Extract entities
+
+#### Extraction patterns (apply per file body)
+
+| Signal in file body | Extract as |
+|---|---|
+| `Телефон:` / `Phone:` / `Tel:` / `+380...` | `hippo:Entity` (contact); include phone in `hippo:summary` |
+| `Сайт:` / `Site:` / `Web:` / bare URL | `hippo:url` on the entity |
+| `#contractor`, `#supplier`, `#vendor`, `#постачальник`, `#підрядник` | `hippo:hasTag` to corresponding tag resource |
+| `tags: [...]` in YAML frontmatter | One `hippo:hasTag` per tag |
+| H1 of a contact/supplier file | The entity name (use original-language label, ASCII slug) |
+| Address / `Адреса:` / `вул.` / street | Include in `hippo:summary` |
+| Comparison table (companies × criteria, "Порівняння", "vs") | One `hippo:Entity` per row + one `hippo:Decision` if a winner is marked (✅, **bold**, "Вибрано", "Decided") with `hippo:references` to all candidates |
+| Price / `Ціна:` / `грн` / `UAH` / `USD` in a quote context | Include the figure in `hippo:summary` of the quoting entity |
+| `Рішення:` / `Decision:` / "Вибрано X тому що Y" | `hippo:Decision` with `hippo:rationale=Y` and `hippo:references` to entities involved |
+| Bullet starting with `?`, `TODO`, `Питання:` | `hippo:Question` with `hippo:status="open"` |
+| Inline `[[wiki-link]]` to another note in the project | `hippo:references` from this resource to the linked resource |
 
 For each person, organization, product, place, account, or identifiable thing:
 ```

--- a/internal/setup/skill_content_test.go
+++ b/internal/setup/skill_content_test.go
@@ -1,0 +1,124 @@
+package setup
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// readEmbeddedSkill runs Setup into a temp dir and returns the project-analyze
+// skill body. We read through Setup (rather than the embed FS directly) to also
+// cover the write path.
+func readEmbeddedSkill(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := Setup(dir, ""); err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+	body, err := os.ReadFile(filepath.Join(dir, ".claude", "skills", "project-analyze.md"))
+	if err != nil {
+		t.Fatalf("read skill: %v", err)
+	}
+	return string(body)
+}
+
+// TestSkill_NoBrokenProjPrefix guards the fix in PR #4: the `proj:` prefix
+// mapping `https://hippocamp.dev/project/` produces invalid TriG because slashes
+// are not allowed in a prefixed-name local part. The skill must not advise it.
+func TestSkill_NoBrokenProjPrefix(t *testing.T) {
+	body := readEmbeddedSkill(t)
+
+	if strings.Contains(body, "prefix=proj uri=https://hippocamp.dev/project/") {
+		t.Error("skill still registers the broken proj: prefix; see PR #4")
+	}
+	if strings.Contains(body, "prefix_add prefix=proj") {
+		t.Error("skill registers a proj: prefix — slashes in local part will fail TriG parse")
+	}
+	// The replacement guidance must be present.
+	if !strings.Contains(body, "Do NOT register a `proj:` prefix") {
+		t.Error("skill missing the explicit warning against proj: prefix")
+	}
+}
+
+// TestSkill_DeepScanProcedure guards the Step 3 rewrite: shallow root-only
+// scans miss subfolder content (e.g. contacts/). The skill must prescribe a
+// recursive scan with named subfolder hints.
+func TestSkill_DeepScanProcedure(t *testing.T) {
+	body := readEmbeddedSkill(t)
+
+	mustContain := []string{
+		"DEEP, not shallow",
+		"find . -maxdepth 4",
+		"Read every leaf file",
+		"Sanity check",
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(body, s) {
+			t.Errorf("skill missing deep-scan marker: %q", s)
+		}
+	}
+
+	// Subfolder hints — at least these bilingual ones.
+	hints := []string{"contacts/", "контакти/", "suppliers/", "постачальники/", "decisions/"}
+	for _, h := range hints {
+		if !strings.Contains(body, h) {
+			t.Errorf("skill missing subfolder hint: %q", h)
+		}
+	}
+}
+
+// TestSkill_NoDuplicateQuotesHint catches the post-review nit: `quotes/` was
+// listed twice in the subfolder hint line.
+func TestSkill_NoDuplicateQuotesHint(t *testing.T) {
+	body := readEmbeddedSkill(t)
+
+	for _, line := range strings.Split(body, "\n") {
+		if !strings.Contains(line, "Identify content-bearing subfolders") {
+			continue
+		}
+		if n := strings.Count(line, "`quotes/`"); n > 1 {
+			t.Errorf("subfolder hint line lists `quotes/` %d times, want 1", n)
+		}
+		return
+	}
+	t.Error("subfolder hint line not found")
+}
+
+// TestSkill_ExtractionPatternsTable guards the Step 6 patterns table that
+// codifies signal→RDF mapping (phone → Entity, ✅ → Decision, etc.).
+func TestSkill_ExtractionPatternsTable(t *testing.T) {
+	body := readEmbeddedSkill(t)
+
+	if !strings.Contains(body, "Extraction patterns") {
+		t.Fatal("skill missing 'Extraction patterns' section")
+	}
+
+	// Each row encodes a high-value pattern. Drop one and the agent loses it.
+	patterns := []string{
+		"`Телефон:`",
+		"`hippo:url`",
+		"`#supplier`",
+		"hippo:Decision",
+		"hippo:rationale",
+		"`hippo:references`",
+		"hippo:Question",
+		"`[[wiki-link]]`",
+	}
+	for _, p := range patterns {
+		if !strings.Contains(body, p) {
+			t.Errorf("extraction patterns table missing: %q", p)
+		}
+	}
+}
+
+// TestSkill_ImportTargetsDefaultGraphNote keeps the warning about
+// `graph action=import` writing to the default graph (the trap that motivated
+// the proj: fix in the first place).
+func TestSkill_ImportTargetsDefaultGraphNote(t *testing.T) {
+	body := readEmbeddedSkill(t)
+
+	if !strings.Contains(body, "graph action=import") || !strings.Contains(body, "default graph") {
+		t.Error("skill missing the note that graph action=import writes to default graph")
+	}
+}


### PR DESCRIPTION
## Summary

Three fixes to the embedded `project-analyze` skill, all surfaced by a real run on a multi-folder Obsidian vault (~17 projects, mixed UA/EN content):

1. **Step 1 — drop the `proj:` prefix.** The example mapping `proj: → https://hippocamp.dev/project/` produces invalid TriG: slashes aren't allowed in the local part of a prefixed name, so `proj:topic/foo` fails with `expected ':' in prefixed name`. The first `graph action=import` of any non-trivial graph dies on this. Replaced with full URIs everywhere + an explicit warning.

   Also added a note that `graph action=import` ignores named-graph and writes to default (this matches the API but isn't reflected anywhere in the skill — agents currently write `graph action=import data=...` after `graph action=create name=project:foo` and silently get a default-graph result).

2. **Step 3 — rewrite "Scan the project" from shallow to deep.** Old wording ("Read the directory structure and key files") allowed the agent to stop at the root README + a single `ls`, missing every content-bearing subfolder. In my run, `projects/house/контакти/*.md` (7 suppliers with phones, URLs, comparison-table decision) was completely skipped — the user had to ask "а постачальники?" before they showed up. New procedure prescribes:
   - Recursive `find -maxdepth 4`
   - Named list of subfolder patterns that almost always carry entities (`contacts/`, `контакти/`, `suppliers/`, `materials/`, `decisions/`, …)
   - Explicit "read every leaf file" rule
   - Sanity check on entity count vs subfolder size
   - Allowed skips (binary/image, archive, generated, per-day journals)

3. **Step 6 — add an extraction-patterns table.** Codifies the per-file signal → RDF mapping that was previously rediscovered each run: `Телефон:` → contact entity, URL → `hippo:url`, `#supplier` → tag, comparison table with ✅ → Decision + references to all candidates, `Рішення: X тому що Y` → Decision with rationale, `[[wiki-link]]` → `hippo:references`, etc. This is the concrete piece that makes "extract entities" no longer a guessing game.

## Effect on the smoke test

After applying these to my vault copy, a fresh `/project-analyze` would have caught all 7 house suppliers + the geology-contractor decision (Мірничий vs Геотоп, ✅ marker → automatic Decision with rationale and references) on the first pass, instead of requiring a follow-up prompt.

## Test plan

- [ ] Run `/project-analyze` on a project with content-bearing subfolders (e.g. `contacts/`, `suppliers/`); confirm files inside are read on first pass.
- [ ] Confirm the existing `graph action=import` example in any docs still parses (no change to the example itself, only removed the broken `proj:` prefix line above it).
- [ ] Spot-check that none of the upstream features added since this skill last shipped (Step 1.5 schema migrations, Step 12 fuzzy validate, Step 13 consolidate, Step 14 dump, provenance/temporal properties) were touched — only Steps 1, 3, and 6 changed.